### PR TITLE
[ Fix ] Increased logo top and bottom offset for better mobile view  & fixed encoding character

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -561,7 +561,7 @@ var _open = [
     ["A63", "Benoni: Fianchetto, 9...Nbd7", "1.d4 Nf6 2.c4 c5 3.d5 e6 4.Nc3 exd5 5.cxd5 d6 6.Nf3 g6 7.g3 Bg7 8.Bg2 O-O 9.O-O Nbd7", 46, 1],
     ["E23", "Nimzo-Indian: Spielmann, 4...c5 5.dxc5 Nc6", "1.d4 Nf6 2.c4 e6 3.Nc3 Bb4 4.Qb3 c5 5.dxc5 Nc6", 56, 1],
     ["E79", "King's Indian: Four Pawns Attack, Main Line", "1.d4 Nf6 2.c4 g6 3.Nc3 Bg7 4.e4 d6 5.f4 O-O 6.Be2 c5 7.Nf3 cxd4 8.Nxd4 Nc6 9.Be3", 59, 1],
-    ["B85", "Sicilian: Scheveningen, Classical, 7…Qc7 8.f4 Nc6", "1.e4 c5 2.Nf3 d6 3.d4 cxd4 4.Nxd4 Nf6 5.Nc3 e6 6.Be2 a6 7.O-O Qc7 8.f4 Nc6", 57, 1],
+    ["B85", "Sicilian: Scheveningen, Classical, 7ï¿½Qc7 8.f4 Nc6", "1.e4 c5 2.Nf3 d6 3.d4 cxd4 4.Nxd4 Nf6 5.Nc3 e6 6.Be2 a6 7.O-O Qc7 8.f4 Nc6", 57, 1],
     ["E89", "King's Indian: Saemisch, Orthodox Main Line", "1.d4 Nf6 2.c4 g6 3.Nc3 Bg7 4.e4 d6 5.f3 O-O 6.Be3 e5 7.d5 c6 8.Nge2 cxd5", 53, 1],
     ["D99", "Gruenfeld: Russian, Smyslov, Main Line", "1.d4 Nf6 2.c4 g6 3.Nc3 d5 4.Nf3 Bg7 5.Qb3 dxc4 6.Qxc4 O-O 7.e4 Bg4 8.Be3 Nfd7 9.Qb3", 57, 1],
     ["A00", "Clemenz Opening", "1.h3", 45, 1],
@@ -5471,7 +5471,7 @@ function setupMobileLayout(init)
         document.getElementById('wGraph').style.display = "none";
         document.getElementById('wHistory').style.display = "none";
         document.getElementById('wMoves').style.height = "121px";
-        document.getElementById('logo').style.height = "20px";
+        document.getElementById('logo').style.height = "30px";
         document.getElementById('logo').style.padding = "0";
         document.getElementById('logo').style.transform = "scale(0.5)";
         document.getElementById('logo').style.transformOrigin = "top left";
@@ -5530,6 +5530,7 @@ function setupMobileLayout(init)
     document.getElementById('wb').style.height = horiz ? "120px" : "";
     document.getElementById('colLeft').style.minWidth = horiz ? "300px" : "";
     document.getElementById('colLeft').style.minHeight = horiz ? "1px" : "338px";
+    document.getElementById('colLeft').style.paddingTop = horiz ? "" : "6px";
     document.getElementById('colLeft').style.paddingBottom = horiz ? "" : "24px";
     document.getElementById('colLeft').style.marginLeft = horiz ? "5px" : "10px";
     document.getElementById('colRight').style.marginLeft = horiz ? "45px" : "10px";

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -561,7 +561,7 @@ var _open = [
     ["A63", "Benoni: Fianchetto, 9...Nbd7", "1.d4 Nf6 2.c4 c5 3.d5 e6 4.Nc3 exd5 5.cxd5 d6 6.Nf3 g6 7.g3 Bg7 8.Bg2 O-O 9.O-O Nbd7", 46, 1],
     ["E23", "Nimzo-Indian: Spielmann, 4...c5 5.dxc5 Nc6", "1.d4 Nf6 2.c4 e6 3.Nc3 Bb4 4.Qb3 c5 5.dxc5 Nc6", 56, 1],
     ["E79", "King's Indian: Four Pawns Attack, Main Line", "1.d4 Nf6 2.c4 g6 3.Nc3 Bg7 4.e4 d6 5.f4 O-O 6.Be2 c5 7.Nf3 cxd4 8.Nxd4 Nc6 9.Be3", 59, 1],
-    ["B85", "Sicilian: Scheveningen, Classical, 7�Qc7 8.f4 Nc6", "1.e4 c5 2.Nf3 d6 3.d4 cxd4 4.Nxd4 Nf6 5.Nc3 e6 6.Be2 a6 7.O-O Qc7 8.f4 Nc6", 57, 1],
+    ["B85", "Sicilian: Scheveningen, Classical, 7♛Qc7 8.f4 Nc6", "1.e4 c5 2.Nf3 d6 3.d4 cxd4 4.Nxd4 Nf6 5.Nc3 e6 6.Be2 a6 7.O-O Qc7 8.f4 Nc6", 57, 1],
     ["E89", "King's Indian: Saemisch, Orthodox Main Line", "1.d4 Nf6 2.c4 g6 3.Nc3 Bg7 4.e4 d6 5.f3 O-O 6.Be3 e5 7.d5 c6 8.Nge2 cxd5", 53, 1],
     ["D99", "Gruenfeld: Russian, Smyslov, Main Line", "1.d4 Nf6 2.c4 g6 3.Nc3 d5 4.Nf3 Bg7 5.Qb3 dxc4 6.Qxc4 O-O 7.e4 Bg4 8.Be3 Nfd7 9.Qb3", 57, 1],
     ["A00", "Clemenz Opening", "1.h3", 45, 1],


### PR DESCRIPTION
I found only one element that is overlapping. You can check this element in the picture below:

![image](https://github.com/LabinatorSolutions/boldchess-web-app/assets/32545344/07a28930-b995-4237-ac41-7839a0bcab55)

This addreses the issue where Interactive elements like links should have enough space around them, to be easy enough to tap without overlapping onto other element. in this case search form element. Increasing space around logo link fixed the problem.

- issue #2
- fixed encoding character (the script previously failed to recognize the character '♛' (U+2029C7))
