### PR TITLE
Refactor route handling to use app.use for serving the main HTML file

### DIFF
--- a/server.js
+++ b/server.js
@@ -78,7 +78,7 @@ app.use((req, res, next) => {
 });
 
 // Send the main HTML file for any other requests (Single Page Application)
-app.get('*', (req, res) => {
+app.use((req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
This pull request includes a small change to the routing logic in `server.js`. The change replaces `app.get('*')` with `app.use()` to handle requests for the main HTML file in a Single Page Application.